### PR TITLE
MAINT: Add skip CI link to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,9 @@ Also, please name and describe your PR as you would write a
 commit message:
 http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message
 
+Depending on your changes, you can skip CI operations and save time and energy: 
+http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping
+
 Note that we are a team of volunteers; we appreciate your
 patience during the review process.
 


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Adds a link to documentation explaining the CI skipping commands we have. We might also need to instruct people on how to amend their commit message, but I am assuming they can do this on their own for now.

#### Additional information
<!--Any additional information you think is important.-->
