### PR TITLE
DOC: Configure JupyterLite's `TryExamples` directive for UNU-RNS tutorial

### DIFF
--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -409,17 +409,18 @@ asv (airspeed velocity)    Recent     https://asv.readthedocs.io/
 Building the Documentation
 --------------------------
 
-====================  =================================================
- Tool                 Version
-====================  =================================================
-Sphinx                Whatever recent versions work. >= 5.0.
-PyData Sphinx theme   Whatever recent versions work. >= 0.15.2.
-Sphinx-Design         Whatever recent versions work. >= 0.4.0.
-numpydoc              Whatever recent versions work. >= 1.5.0.
-matplotlib            Generally suggest >= 3.5.
-MyST-NB               Whatever recent versions work. >= 0.17.1
-jupyterlite-sphinx    Whatever recent versions work. >= 0.12.0
-====================  =================================================
+============================  =================================================
+ Tool                         Version
+====================          =================================================
+Sphinx                        Whatever recent versions work. >= 5.0.
+PyData Sphinx theme           Whatever recent versions work. >= 0.15.2.
+Sphinx-Design                 Whatever recent versions work. >= 0.4.0.
+numpydoc                      Whatever recent versions work. >= 1.5.0.
+matplotlib                    Generally suggest >= 3.5.
+MyST-NB                       Whatever recent versions work. >= 0.17.1
+jupyterlite-sphinx            Whatever recent versions work. >= 0.13.1
+jupyterlite-pyodide-kernel    Whatever recent versions work. >= 0.1.0
+============================  =================================================
 
 .. note::
 

--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -411,7 +411,7 @@ Building the Documentation
 
 ============================  =================================================
  Tool                         Version
-====================          =================================================
+============================          =================================================
 Sphinx                        Whatever recent versions work. >= 5.0.
 PyData Sphinx theme           Whatever recent versions work. >= 0.15.2.
 Sphinx-Design                 Whatever recent versions work. >= 0.4.0.

--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -411,7 +411,7 @@ Building the Documentation
 
 ============================  =================================================
  Tool                         Version
-============================          =================================================
+============================  =================================================
 Sphinx                        Whatever recent versions work. >= 5.0.
 PyData Sphinx theme           Whatever recent versions work. >= 0.15.2.
 Sphinx-Design                 Whatever recent versions work. >= 0.4.0.

--- a/doc/source/try_examples.json
+++ b/doc/source/try_examples.json
@@ -1,4 +1,3 @@
 {
-    "min_height": "400px",
-    "ignore_patterns": [".*"]
+    "min_height": "400px"
 }

--- a/doc/source/tutorial/stats/sampling.md
+++ b/doc/source/tutorial/stats/sampling.md
@@ -142,19 +142,21 @@ samples from the given distribution.
 
 An example of this interface is shown below:
 
-```python
+```{eval-rst}
+.. try_examples::
+
     >>> from scipy.stats.sampling import TransformedDensityRejection
     >>> from math import exp
-    >>> 
+    ...
     >>> class StandardNormal:
     ...     def pdf(self, x: float) -> float:
     ...         # note that the normalization constant isn't required
     ...         return exp(-0.5 * x*x)
     ...     def dpdf(self, x: float) -> float:
     ...         return -x * exp(-0.5 * x*x)
-    ... 
+    ...
     >>> dist = StandardNormal()
-    >>> 
+    ...
     >>> urng = np.random.default_rng()
     >>> rng = TransformedDensityRejection(dist, random_state=urng)
 ```
@@ -188,7 +190,11 @@ In the above example, we have set up an object of the
 standard normal distribution. Now, we can start sampling from our
 distribution by calling the `rvs` method:
 
-```python
+```{eval-rst}
+.. try_examples::
+
+    >>> from scipy.stats.sampling import TransformedDensityRejection
+    >>> rng = TransformedDensityRejection(dist, domain=(-1, 1), random_state=urng)
     >>> rng.rvs()
     -1.526829048388144
     >>> rng.rvs((5, 3))
@@ -213,15 +219,15 @@ mystnb:
     >>> from scipy.stats import norm
     >>> from scipy.stats.sampling import TransformedDensityRejection
     >>> from math import exp
-    >>> 
+    >>>
     >>> class StandardNormal:
     ...     def pdf(self, x: float) -> float:
     ...         # note that the normalization constant isn't required
     ...         return exp(-0.5 * x*x)
     ...     def dpdf(self, x: float) -> float:
     ...         return -x * exp(-0.5 * x*x)
-    ... 
-    >>> 
+    ...
+    >>>
     >>> dist = StandardNormal()
     >>> urng = np.random.default_rng()
     >>> rng = TransformedDensityRejection(dist, random_state=urng)
@@ -258,7 +264,7 @@ mystnb:
   {class}`~.stats.sampling.TransformedDensityRejection` would not be the same
   even for the same `random_state`:
 
-  ```python
+  ```{eval-rst}
     >>> from scipy.stats.sampling import norm, TransformedDensityRejection
     >>> from copy import copy
     >>> dist = StandardNormal()
@@ -274,7 +280,10 @@ mystnb:
 
 We can pass a `domain` parameter to truncate the distribution:
 
-```python
+```{eval-rst}
+.. try_examples::
+
+    >>> from scipy.stats.sampling import TransformedDensityRejection
     >>> rng = TransformedDensityRejection(dist, domain=(-1, 1), random_state=urng)
     >>> rng.rvs((5, 3))
     array([[-0.99865691,  0.38104014,  0.31633526],

--- a/environment.yml
+++ b/environment.yml
@@ -45,6 +45,7 @@ dependencies:
   - jupytext
   - myst-nb
   - jupyterlite-sphinx>=0.13.1
+  - jupyterlite-pyodide-kernel
   # Some optional test dependencies
   - mpmath
   - gmpy2


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

See https://github.com/scipy/scipy/pull/20303 for more information

#### What does this implement/fix?

This PR addresses the following changes:

1. adds `jupyterlite-pyodide-kernel` as a dependency to debug changes to Examples enabled with `jupyterlite-sphinx`,
2. wraps all code blocks in the `sampling.md` file with `{eval-rst}` to let `jupyterlite-sphinx` correctly interpret them and parse code snippets from them, and
3. temporarily enables these examples for debugging purposes.

#### Additional information
<!--Any additional information you think is important.-->

N/A
